### PR TITLE
Add SP as metric, not callback

### DIFF
--- a/ci/main.py
+++ b/ci/main.py
@@ -4,11 +4,14 @@
 
 from test_import import test_import
 from test_callbacks import test_sp_callback
+from test_sp_metric import test as test_metric
 
 
 if __name__ == '__main__':
     print (" ===> BEGIN CI TEST <=== ")
     print (" ==> Import saphyra test")
     test_import()
-    print (" ==> Training a basic model with SP callback")
+    # print (" ==> Training a basic model with SP callback")
     #test_sp_callback()
+    print (" ==> Testing SP metric")
+    test_metric()

--- a/ci/main.py
+++ b/ci/main.py
@@ -3,7 +3,7 @@
 #
 
 from test_import import test_import
-from test_callbacks import test_sp_callback
+# from test_callbacks import test_sp_callback
 from test_sp_metric import test as test_metric
 
 

--- a/ci/test_sp_metric.py
+++ b/ci/test_sp_metric.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import tensorflow as tf
 from tensorflow import keras
-from saphyra import SP_Metric
+from saphyra.metrics.metrics import SP_Metric
 from sklearn.model_selection import train_test_split
 import numpy as np
 

--- a/ci/test_sp_metric.py
+++ b/ci/test_sp_metric.py
@@ -29,9 +29,9 @@ def test():
       tf.keras.layers.Flatten(input_shape=(3,)),
       tf.keras.layers.Dense(2, activation='relu'),
       tf.keras.layers.Dropout(0.2),
-      tf.keras.layers.Dense(1)
+      tf.keras.layers.Dense(1, activation='sigmoid')
     ])
-    model.compile('adam', loss='mse', metrics=[SP_Metric()])
+    model.compile('adam', loss='binary_crossentropy', metrics=[SP_Metric()])
     model.fit (
         x_train, y_train,
         epochs = 5000,

--- a/ci/test_sp_metric.py
+++ b/ci/test_sp_metric.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import tensorflow as tf
+from tensorflow import keras
+from saphyra import SP_Metric
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+def test():
+
+    print(tf.__version__)
+    x_train = np.array([
+        [1, 3, 5],
+        [7, 8, 9],
+        [2, 4, 6],
+    ])
+    y_train = np.array([
+        1, 0, 1
+    ])
+    x_valid = np.array([
+        [1, 2, 3],
+        [2, 3, 1],
+        [9, 8, 7]
+    ])
+    y_valid = np.array([
+        1, 1, 0
+    ])
+    model = tf.keras.models.Sequential([
+      tf.keras.layers.Flatten(input_shape=(3,)),
+      tf.keras.layers.Dense(2, activation='relu'),
+      tf.keras.layers.Dropout(0.2),
+      tf.keras.layers.Dense(1)
+    ])
+    model.compile('adam', loss='mse', metrics=[SP_Metric()])
+    model.fit (
+        x_train, y_train,
+        epochs = 5000,
+        batch_size = 256,
+        verbose = True,
+        validation_data = (x_valid, y_valid),
+        shuffle = True
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ six>=1.12.0
 scipy>=1.4.1
 future
 sklearn
-Gaugi>=1.0.0
+Gaugi==1.0.11
 pandas
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ six>=1.12.0
 scipy>=1.4.1
 future
 sklearn
-Gaugi==1.0.11
+Gaugi>=1.0.13
 pandas
 matplotlib

--- a/saphyra/metrics/metrics.py
+++ b/saphyra/metrics/metrics.py
@@ -1,7 +1,11 @@
 
-__all__ = ["auc", "f1_score"]
+__all__ = [
+  "auc",
+  "f1_score",
+  "SP_Metric",
+]
 
-
+from tensorflow.keras.metrics import AUC
 from tensorflow.keras import backend as K
 
 
@@ -17,3 +21,33 @@ def f1_score(y_true, y_pred):
   f1 = tf.contrib.metrics.f1_score(y_true, y_pred)[1]
   K.get_session().run(tf.local_variables_initializer())
   return f1
+
+###
+#
+# => SP metric
+# 
+# PS: name is SP_Metric so it won't
+# conflict with legacy "sp" metric,
+# which is actually a callback.
+#
+# Using this class, you may add it to
+# your `model.compile` method like the
+# following:
+#
+# model.compile (optimizer='...', loss='...', metrics=[SP_Metric()]) 
+#
+###
+class SP_Metric (AUC):
+
+  # This implementation works with Tensorflow backend tensors.
+  # That way, calculations happen faster and results can be seen
+  # while training, not only after each epoch
+
+  def result(self):
+
+    # Add K.epsilon() for forbiding division by zero
+    fa = self.false_positives / (self.true_negatives + self.false_positives + K.epsilon())
+    pd = self.true_positives  / (self.true_positives + self.false_positives + K.epsilon())
+    sp = K.sqrt(  K.sqrt(pd*(1-fa)) * (0.5*(pd+(1-fa)))  )
+    knee = K.argmax(sp)
+    return sp[knee]

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ setuptools.setup(
   install_requires=[
           #'tensorflow', # this cause an missmatch into the tensorflow docker image. We will install manually in case of not found.
           'keras',
-          'numpy',
-          'six',
-          'scipy',
+          'numpy>=1.18.1',
+          'six>=1.12.0',
+          'scipy>=1.4.1',
           'future',
           'sklearn',
-          'Gaugi',
+          'Gaugi==1.0.11',
           'pandas',
           'matplotlib',
       ],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
           'scipy>=1.4.1',
           'future',
           'sklearn',
-          'Gaugi==1.0.11',
+          'Gaugi>=1.0.13',
           'pandas',
           'matplotlib',
       ],


### PR DESCRIPTION
This allows the following usage:

```py
from saphyra import SP_Metric

model = get_model()
model.compile(optimizer=OPT, loss=LOSS, metrics=[ SP_Metric() ])
```

That way, while training, you'll get something like this while training, not at the end of each epoch:

```
Epoch 1/5000
1/1 [==============================] - 0s 269ms/step - loss: 0.8698 - sp__metric: 1.0000 - val_loss: 0.6528 - val_sp__metric: 1.0000
```

Besides that, it's implemented using Tensorflow backend, which can be compiled and optimized, thus running faster.